### PR TITLE
Refactor player classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,8 @@ Layout/CaseIndentation:
   EnforcedStyle: end
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
+Lint/MissingSuper:
+  Enabled: false # Exclude doesn't seem to work??
 Metrics/AbcSize:
   Max: 20
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ source 'https://rubygems.org' do
 end
 
 group :test do
+  gem 'pry'
   gem 'simplecov'
   gem 'vcr'
   gem 'webmock', '~> 3.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,20 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    coderay (1.1.3)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
     hashdiff (1.0.1)
     json (2.6.3)
+    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     rainbow (3.1.1)
     regexp_parser (2.6.2)
@@ -70,6 +75,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   rspec (~> 3.10)!
   rubocop (~> 1.43)!
   rubocop-rspec!

--- a/lib/rs_api.rb
+++ b/lib/rs_api.rb
@@ -11,8 +11,9 @@ require_relative 'rs_api/version'
 # Base RsApi module for autoloading files
 module RsApi
   autoload :RsConstants, 'rs_api/rs_constants'
-  autoload :PlayerCompare, 'rs_api/rs_player_compare'
-  autoload :PlayerExperience, 'rs_api/rs_player_experience'
+  autoload :PlayerCompare, 'rs_api/hiscores/rs_player_compare'
+  autoload :PlayerExperience, 'rs_api/hiscores/rs_player_experience'
+  autoload :Hiscore, 'rs_api/hiscores/hiscore'
   autoload :RsRequest, 'rs_api/rs_request'
   autoload :PlayerNameHelper, 'rs_api/helpers/player_name_helper'
   autoload :Runemetrics, 'rs_api/runemetrics/rs_runemetrics'

--- a/lib/rs_api/hiscores/hiscore.rb
+++ b/lib/rs_api/hiscores/hiscore.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Uncomment below to run Examples in file. Continue for other related files
+# require_relative '../helpers/player_name_helper'
+# require_relative '../rs_constants'
+
+module RsApi
+  # Base class for getting Runescape hiscore data for a player
+  class Hiscore
+    class PlayerNotFound < StandardError; end
+    include PlayerNameHelper
+    include RsConstants
+
+    private
+
+    def display?
+      RsApi.load_config['display_output']
+    end
+
+    def params
+      raise 'implement me!'
+    end
+
+    def table
+      @table ||= Text::Table.new(horizontal_padding: 2)
+    end
+
+    def url
+      raise 'implement me!'
+    end
+  end
+end

--- a/lib/rs_api/hiscores/rs_player_compare.rb
+++ b/lib/rs_api/hiscores/rs_player_compare.rb
@@ -2,17 +2,16 @@
 
 # Uncomment below to run Example(s) in file. May also need to for other related files.
 # require 'text-table'
-# require_relative 'rs_request'
-# require_relative 'rs_int_extend'
-# require_relative 'rs_constants'
+# require_relative 'hiscore'
+# require_relative '../rs_request'
+# require_relative '../rs_int_extend'
+# require_relative '../rs_constants'
 # require_relative 'rs_player_experience'
 
 module RsApi
   # class PlayerCompare that compares two PlayerExp skill experience.
-  class PlayerCompare
+  class PlayerCompare < Hiscore
     attr_reader :player1, :player2
-
-    include RsConstants
 
     def initialize(player1, player2)
       @player1 = PlayerExperience.new(player1)
@@ -22,22 +21,24 @@ module RsApi
     def compare
       SKILL_ID_CONST.each do |key, skill_name|
         diff = @player1.all_skill_experience[key] - @player2.all_skill_experience[key]
-        formatted_skill_name = skill_name.capitalize
 
         results << case diff <=> 0
-        when -1
-          [formatted_skill_name, @player2.username, -diff]
-        when 1
-          [formatted_skill_name, @player1.username, diff]
+        when -1 # p2 has more skill
+          [capitalize(skill_name), @player2.player_name, diff.abs]
+        when 1 # p1 has more skill
+          [capitalize(skill_name), @player1.player_name, diff]
         else # 0
-          [formatted_skill_name, 'TIE', 0]
+          [capitalize(skill_name), 'TIE', 0]
         end
       end
     end
 
     def display
-      compare if results.empty?
-      table.head = %w[SKILL WINNER XP-DIFFERENCE]
+      if results.empty?
+        compare
+        table.head = %w[SKILL WINNER XP-DIFFERENCE]
+        table.rows = formatted_results
+      end
       puts table if display?
     end
 
@@ -47,20 +48,12 @@ module RsApi
 
     private
 
-    def display?
-      RsApi.load_config['display_output']
+    def capitalize(value)
+      value.capitalize
     end
 
     def formatted_results
-      f_result = results.dup
-      f_result.each do |result|
-        result[2] = result[2].delimited
-      end
-      f_result
-    end
-
-    def table
-      @table ||= Text::Table.new(rows: formatted_results, horizontal_padding: 2)
+      results.map { |i, j, k| [i, j, k.delimited] }
     end
   end
 end

--- a/lib/rs_api/hiscores/rs_player_experience.rb
+++ b/lib/rs_api/hiscores/rs_player_experience.rb
@@ -2,27 +2,28 @@
 
 # Uncomment below to run Example(s) in file. May also need to for other related files.
 # require 'text-table'
-# require_relative 'rs_request'
-# require_relative 'rs_int_extend'
-# require_relative 'rs_constants'
+# require_relative 'hiscore'
+# require_relative '../rs_request'
+# require_relative '../rs_int_extend'
+# require_relative '../rs_constants'
 
 module RsApi
   # Class PlayerExp pulls, from Hiscores, player level/experience in each skill.
-  class PlayerExperience
-    class PlayerNotFound < StandardError; end
-    attr_reader :username
+  class PlayerExperience < Hiscore
+    attr_reader :player_name, :table_results
 
-    include RsConstants
-
-    def initialize(username)
-      @username = username
+    def initialize(player_name)
+      PlayerNameHelper.check_player_name(player_name)
+      @player_name = player_name
     end
 
+    # Pull puts form here, make display return table object
+    # Then a print method can be included? or used separately?
     def display
-      table_data if table.rows.empty?
-      puts table if display?
-    rescue PlayerNotFound => e
-      puts "#{e} | '#{@username}' does not exist." if display?
+      fill_table_data if table.rows.empty?
+      display? ? (p table) : table
+    rescue PlayerNotFound
+      puts "#{@player_name} does not exist." if display?
     end
 
     def loaded_xp
@@ -50,47 +51,37 @@ module RsApi
 
     private
 
-    def display?
-      RsApi.load_config['display_output']
-    end
-
-    def table
-      @table ||= Text::Table.new(horizontal_padding: 2)
-    end
-
-    def table_data
-      table.head = [{ value: "Player: #{@username}", colspan: 3, align: :center }]
+    def fill_table_data
+      table.head = [{ value: "Player: #{player_name}", colspan: 3, align: :center }]
 
       loaded_xp.each_with_index do |value, i|
         table.rows << if i.zero?
-          [SKILL_ID_CONST[i].to_s.capitalize, "Total Level: #{value[1]}", "Total Experience: #{value[2]}"]
+          [SKILL_ID_CONST[i].capitalize, "Total Level: #{value[1]}", "Total Experience: #{format(value[2])}"]
         else
-          [SKILL_ID_CONST[i].to_s.capitalize, "Level: #{value[1]}", "Experience: #{value[2]}"]
+          [SKILL_ID_CONST[i].capitalize, "Level: #{value[1]}", "Experience: #{format(value[2])}"]
         end
       end
     end
 
     def format(value)
-      value = value.split(',')
-      value[2] = value[2].to_i.delimited
-      value
+      value.to_i.delimited
     end
 
-    def hiscore_url
-      # Url for Runescape's Highscore API
+    def url
+      # Url for Runescape 3's Highscore API
       'https://secure.runescape.com/m=hiscore/index_lite.ws?'
     end
 
     def parsed
       # Response is in CSV format
-      response = RsRequest.new(hiscore_url, params).get
+      response = RsRequest.new(url, params).get
       raise PlayerNotFound if response.message == 'Not Found'
 
-      response.body.split(/\n/).map { |item| format(item) }
+      response.body.split(/\n/).map { |item| item.split(',') }
     end
 
     def params
-      { player: @username }
+      { player: player_name }
     end
   end
 end

--- a/spec/lib/rs_api/hiscores/hiscore_spec.rb
+++ b/spec/lib/rs_api/hiscores/hiscore_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RsApi
+  class Hiscore
+    RSpec.describe Hiscore do
+      let(:service) { described_class.new }
+
+      it 'has default params' do
+        expect { service.send(:params) }.to raise_error(RuntimeError, 'implement me!')
+      end
+
+      it 'has default url' do
+        expect { service.send(:url) }.to raise_error(RuntimeError, 'implement me!')
+      end
+    end
+  end
+end

--- a/spec/lib/rs_api/hiscores/player_compare_spec.rb
+++ b/spec/lib/rs_api/hiscores/player_compare_spec.rb
@@ -10,9 +10,9 @@ module RsApi
 
       it 'Initializes PlayerCompare' do
         expect(service.player1.class).to eq(PlayerExperience)
-        expect(service.player1.username).to eq('player1')
+        expect(service.player1.player_name).to eq('player1')
         expect(service.player2.class).to eq(PlayerExperience)
-        expect(service.player2.username).to eq('player2')
+        expect(service.player2.player_name).to eq('player2')
       end
 
       describe 'compares players' do
@@ -53,7 +53,7 @@ module RsApi
           end
         end
 
-        it 'displays player xp comparison' do
+        it 'display xp comparison' do
           VCR.use_cassette('player_compare__successful__different_xp', erb:) do
             # Can something else help test text from puts?
             expect { service.display }.not_to raise_error

--- a/spec/lib/rs_api/hiscores/player_experience_spec.rb
+++ b/spec/lib/rs_api/hiscores/player_experience_spec.rb
@@ -21,11 +21,12 @@ module RsApi
       it 'displays PlayerNotFound' do
         unknown_name = 'unknown'
         erb = { player_name: unknown_name }
+        RsApi.stub(:load_config).and_return({ display_output: true })
 
         # I need to allow playback repeats because `loaded_xp` has no data
         VCR.use_cassette('player_experience__not_found', erb:, allow_playback_repeats: true) do
           service = described_class.new(unknown_name)
-
+          # binding.pry
           # Can something else help test text from puts?
           expect(service.display).to be_nil
           expect { service.display }.not_to raise_error
@@ -33,7 +34,7 @@ module RsApi
       end
 
       it 'sets username' do
-        expect(player.username).to eq(player_name)
+        expect(player.player_name).to eq(player_name)
       end
 
       context 'when request successful' do
@@ -48,10 +49,10 @@ module RsApi
 
         it 'formats experience' do
           VCR.use_cassette('player_experience__successful', erb: { player_name: }) do
-            player_xp = player.loaded_xp
+            table = player.display
 
             # confirm experience value is formatted with .delimited
-            expect(player_xp[0][2]).to include(',').at_least(:once)
+            expect(table.rows.last[2]).to include(',').at_least(:once)
           end
         end
 
@@ -59,7 +60,7 @@ module RsApi
           VCR.use_cassette('player_experience__successful', erb: { player_name: }) do
             # Can something else help test text from puts?
             expect { player.display }.not_to raise_error
-            expect(player.display).to be_nil
+            expect(player.display).to be_instance_of(Text::Table)
           end
         end
 


### PR DESCRIPTION
Refactor the `PlayerExperience` and `PlayerCompare` classes to inheret from `Hiscore` class. This is because of many overlapping functions that are related to each other