### PR TITLE
Formalize use of `raw_data` method across classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ user.display
 +---------------+---------+-------+-------------+
  => #<Text::Table:0xfaf0>
 ```
-An alternative for reciving raw player data is the `#loaded_xp` method.  
+An alternative for reciving raw player data is the `#raw_data` method.
 
 ---
 
@@ -73,6 +73,7 @@ It contains the same `#display` method, but raw data is `#raw_data`.
 
 #### `MonthlyXp`
 class is able to grab the last 12 months of player xp data for every skill.
+Currently only contains the `#raw_data` method.
 
 ---
 

--- a/lib/rs_api/hiscores/rs_player_compare.rb
+++ b/lib/rs_api/hiscores/rs_player_compare.rb
@@ -25,15 +25,15 @@ module RsApi
       SKILL_ID_CONST.each do |key, skill_name|
         xp_diff = @player1.all_skill_experience[key] - @player2.all_skill_experience[key]
 
-        results << compare_result(key, skill_name, xp_diff)
+        raw_data << compare_result(key, skill_name, xp_diff)
       end
     end
 
     def display
-      if results.empty?
+      if raw_data.empty?
         compare
         table.head = %w[SKILL WINNER LEVEL XP-DIFFERENCE]
-        table.rows = formatted_results
+        table.rows = formatted_data
       end
 
       if display?
@@ -44,8 +44,8 @@ module RsApi
       table
     end
 
-    def results
-      @results ||= [] # index 0 is total exp, rest is normal skills by exp
+    def raw_data
+      @raw_data ||= [] # index 0 is total exp, rest is normal skills by exp
     end
 
     private
@@ -75,16 +75,16 @@ module RsApi
     def compare_result(key, skill_name, xp_diff)
       case xp_diff <=> 0
       when -1 # p2 has more skill
-        [capitalize(skill_name), @player2.player_name, @player2.loaded_xp[key][1], xp_diff.abs]
+        [capitalize(skill_name), @player2.player_name, @player2.raw_data[key][1], xp_diff.abs]
       when 1 # p1 has more skill
-        [capitalize(skill_name), @player1.player_name, @player1.loaded_xp[key][1], xp_diff]
+        [capitalize(skill_name), @player1.player_name, @player1.raw_data[key][1], xp_diff]
       else # 0
-        [capitalize(skill_name), 'TIE', @player2.loaded_xp[key][1], 0]
+        [capitalize(skill_name), 'TIE', @player2.raw_data[key][1], 0]
       end
     end
 
-    def formatted_results
-      results.map { |i, j, k, l| [i, j, k, l.delimited] }
+    def formatted_data
+      raw_data.map { |i, j, k, l| [i, j, k, l.delimited] }
     end
   end
 end

--- a/lib/rs_api/hiscores/rs_player_experience.rb
+++ b/lib/rs_api/hiscores/rs_player_experience.rb
@@ -34,19 +34,19 @@ module RsApi
       puts "#{@player_name} does not exist." if display?
     end
 
-    def loaded_xp
-      @loaded_xp ||= parsed[0..29]
+    def raw_data
+      @raw_data ||= parsed[0..29]
     end
 
     def max_skill_level
       # Returns the highest skill level out of all sklls
-      loaded_xp[1..].map { |value| value[1].to_i }.max.to_s
+      raw_data[1..].map { |value| value[1].to_i }.max.to_s
     end
 
     def skills_at_max_level
       # Returns a array containing only skills at max_skill_level
       # SKILL_ID_CONST[i+1] | i is +1 because I don't want to load the overall skill totals
-      loaded_xp[1..].filter_map.with_index do |value, i|
+      raw_data[1..].filter_map.with_index do |value, i|
         SKILL_ID_CONST[i + 1].to_s.capitalize if value[1] == max_skill_level
       end
     end
@@ -54,7 +54,7 @@ module RsApi
     def all_skill_experience
       # Retuns array containing the experience for each skill
       # Index of skills corresponds to RsConst::SKILL_ID_CONST
-      loaded_xp.map { |n| n.last.delete(',').to_i }
+      raw_data.map { |n| n.last.delete(',').to_i }
     end
 
     private
@@ -76,7 +76,7 @@ module RsApi
       table.head = [player_name, 'Rank', 'Level', 'Experience']
 
       # Future: move 'Overall' xp info to footer
-      loaded_xp.each_with_index do |value, i|
+      raw_data.each_with_index do |value, i|
         table.rows << [SKILL_ID_CONST[i].capitalize, format(value[0]), value[1], format(value[2])]
       end
     end

--- a/spec/lib/rs_api/hiscores/player_compare_spec.rb
+++ b/spec/lib/rs_api/hiscores/player_compare_spec.rb
@@ -20,10 +20,10 @@ module RsApi
           VCR.use_cassette('player_compare__successful__tie', erb:) do
             service.compare
 
-            map_of_winners = service.results.map { |result| result[1] }.uniq
-            total_xp_diff = service.results.map { |result| result[3] }.sum
+            map_of_winners = service.raw_data.map { |result| result[1] }.uniq
+            total_xp_diff = service.raw_data.map { |result| result[3] }.sum
 
-            expect(service.results.length).to eq(SKILL_ID_CONST.length)
+            expect(service.raw_data.length).to eq(SKILL_ID_CONST.length)
             expect(map_of_winners.length).to eq(1)
             expect(map_of_winners.first).to eq('TIE')
             expect(total_xp_diff).to eq(0)
@@ -34,10 +34,10 @@ module RsApi
           VCR.use_cassette('player_compare__successful__different_xp', erb:) do
             service.compare
 
-            map_of_winners = service.results.map { |result| result[1] }.uniq
-            total_xp_diff = service.results.map { |result| result[3] }.sum
+            map_of_winners = service.raw_data.map { |result| result[1] }.uniq
+            total_xp_diff = service.raw_data.map { |result| result[3] }.sum
 
-            expect(service.results.length).to eq(SKILL_ID_CONST.length)
+            expect(service.raw_data.length).to eq(SKILL_ID_CONST.length)
             expect(map_of_winners.length).to eq(3)
             expect(map_of_winners.sort).to eq(%w[TIE player1 player2].sort)
             expect(total_xp_diff).not_to eq(0)
@@ -48,8 +48,8 @@ module RsApi
           VCR.use_cassette('player_compare__successful__different_xp', erb:) do
             service.compare
 
-            expect(service.results.class).to eq(Array)
-            expect(service.results.first.class).to eq(Array)
+            expect(service.raw_data.class).to eq(Array)
+            expect(service.raw_data.first.class).to eq(Array)
           end
         end
 

--- a/spec/lib/rs_api/hiscores/player_experience_spec.rb
+++ b/spec/lib/rs_api/hiscores/player_experience_spec.rb
@@ -14,7 +14,7 @@ module RsApi
         VCR.use_cassette('player_experience__not_found', erb:) do
           service = described_class.new(unknown_name)
 
-          expect { service.loaded_xp }.to raise_error(RsApi::PlayerExperience::PlayerNotFound)
+          expect { service.raw_data }.to raise_error(RsApi::PlayerExperience::PlayerNotFound)
         end
       end
 
@@ -23,7 +23,7 @@ module RsApi
         erb = { player_name: unknown_name }
         RsApi.stub(:load_config).and_return({ display_output: true })
 
-        # I need to allow playback repeats because `loaded_xp` has no data
+        # I need to allow playback repeats because `raw_data` has no data
         VCR.use_cassette('player_experience__not_found', erb:, allow_playback_repeats: true) do
           service = described_class.new(unknown_name)
           # binding.pry
@@ -40,7 +40,7 @@ module RsApi
       context 'when request successful' do
         it 'loads xp' do
           VCR.use_cassette('player_experience__successful', erb: { player_name: }) do
-            player_xp = player.loaded_xp
+            player_xp = player.raw_data
 
             expect(player_xp.class).to eq(Array)
             expect(player_xp.length).to eq(SKILL_ID_CONST.length)


### PR DESCRIPTION
I have inconsistent use of `raw_data`, `loaded_xp`, and `results`. All 3 contain practically the same kind of info, but inconsistent naming makes things confusing.